### PR TITLE
Optimize RecentCounter with deque and add tests

### DIFF
--- a/933-number-of-recent-calls.py
+++ b/933-number-of-recent-calls.py
@@ -1,28 +1,36 @@
 """
-You have a RecentCounter class which counts the number of recent requests within a certain time frame.
+RecentCounter tracks the number of requests received in the past 3000 milliseconds.
 
-Implement the RecentCounter class:
+The original implementation used a standard list to store request timestamps and removed
+expired entries with ``pop(0)``. This resulted in ``O(n)`` time complexity per operation,
+which could become slow as the number of requests grew.
 
-RecentCounter() Initializes the counter with zero recent requests.
-int ping(int t) Adds a new request at time t, where t represents some time in milliseconds, and returns the number of requests that has happened in the past 3000 milliseconds (including the new request). Specifically, return the number of requests that have happened in the inclusive range [t - 3000, t].
-It is guaranteed that every call to ping uses a strictly larger value of t than the previous call.
+This version uses ``collections.deque`` to achieve ``O(1)`` removals from the left,
+ensuring that the ``ping`` method runs efficiently.
 """
 
+from collections import deque
+
+
 class RecentCounter:
-   def __init__(self):
-       self.requests = []  # Store the timestamps of ping calls
+    """Count recent requests in the last 3000 milliseconds."""
 
-   def ping(self, t: int) -> int:
-       # Add the current timestamp
-       self.requests.append(t)
+    def __init__(self) -> None:
+        # Using deque allows O(1) pops from the left as older timestamps expire
+        self.requests: deque[int] = deque()
 
-       # Remove requests older than 3000ms
-       while self.requests and self.requests[0] < t - 3000:
-           self.requests.pop(0)
+    def ping(self, t: int) -> int:
+        """Record a new request and return the number within the past 3000 ms."""
 
-       # Return the number of requests in the time window
-       return len(self.requests)
+        # Add the current timestamp
+        self.requests.append(t)
 
+        # Remove requests older than 3000ms
+        while self.requests and self.requests[0] < t - 3000:
+            self.requests.popleft()
+
+        # Return the number of requests in the time window
+        return len(self.requests)
 
 
 # Your RecentCounter object will be instantiated and called as such:

--- a/test_recent_counter.py
+++ b/test_recent_counter.py
@@ -1,0 +1,35 @@
+"""Tests for the RecentCounter class."""
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    """Load the RecentCounter module despite the non-standard filename."""
+
+    module_path = Path(__file__).with_name("933-number-of-recent-calls.py")
+    spec = importlib.util.spec_from_file_location("recent_counter", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def test_recent_counter_basic():
+    module = _load_module()
+    rc = module.RecentCounter()
+
+    assert rc.ping(1) == 1
+    assert rc.ping(100) == 2
+    assert rc.ping(3001) == 3
+    assert rc.ping(3002) == 3
+
+
+def test_recent_counter_sliding_window():
+    module = _load_module()
+    rc = module.RecentCounter()
+
+    times = [1, 100, 3001, 3002, 6000]
+    results = [rc.ping(t) for t in times]
+    # At t=6000, the window [3000, 6000] still contains the three most recent timestamps
+    assert results == [1, 2, 3, 3, 3]
+


### PR DESCRIPTION
## Summary
- Replace list with `collections.deque` in `RecentCounter` for efficient O(1) expiration
- Add unit tests validating `RecentCounter` behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68957f757e148328a3286bb5570ba6e0